### PR TITLE
Add Pubnub keys to app delegate.

### DIFF
--- a/Connnect/AppDelegate.swift
+++ b/Connnect/AppDelegate.swift
@@ -6,7 +6,15 @@
 //  Copyright © 2016 iOS-Connect. All rights reserved.
 //
 
+enum PubNubKeys {
+    static let publish = "pub-c-655893d9-dc93-4586-8fc2-7de8885c522e"
+    static let subscribe = "sub-c-a73426c2-ae81-11e6-a7bb-0619f8945a4f"
+    static let secret = "sec-c-NmI2OTZjYTUtNjI0NC00ZGRlLThiMTktY2YzODUyNmZmY2M2"
+}
+
+
 import UIKit
+
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {


### PR DESCRIPTION
Maybe we'll move them out of the app delegate eventually, but this is fine for now.