### PR TITLE
Added override to allow init from code

### DIFF
--- a/RoundedButton.swift
+++ b/RoundedButton.swift
@@ -12,13 +12,18 @@ class RoundedButton: UIButton{
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        configureRoundedCorners()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureRoundedCorners()
+    }
+
+    private func configureRoundedCorners() {
         self.backgroundColor = .clear
         self.layer.cornerRadius = 10
         self.layer.borderWidth = 2
-        
         self.layer.borderColor = self.tintColor.cgColor
-
     }
-
-    
 }


### PR DESCRIPTION
Without overriding the `init(frame:)` we only get the ability to create
the rounded button from a storyboard or nib. `UIButton` has 2 designated
initilaizers If we only override one of them (`init` with coder, that will
be the only one that is available) if we over ride them both, we also
inherit the convenience initializer for the superclass as well allowing
us to make rounded buttons from storyboard/nib or from code with
`init(frame:)` or `init(type:)`